### PR TITLE
feat: log additionally axios error

### DIFF
--- a/lib/responseBuilder.js
+++ b/lib/responseBuilder.js
@@ -97,7 +97,7 @@ module.exports = function ResponseBuilder() {
    * @private
    */
   self._errorResponse = (error, codeOverride, req) => {
-    if (error.isAxiosError) {
+    if (error && error.isAxiosError) {
       log.error(`@backend-utils:errorResponse - error:axios:${JSON.stringify(self._getAxiosError(error))}`);
     }
 

--- a/lib/responseBuilder.js
+++ b/lib/responseBuilder.js
@@ -52,6 +52,43 @@ module.exports = function ResponseBuilder() {
   };
 
   /**
+   * Return error object with only necessary props according to axios docs https://github.com/axios/axios#handling-errors
+   * @param {Error} axiosError axios error object
+   * @return {number} http code
+   * @private
+   */
+  self._getAxiosError = (axiosError) => {
+    const errorInfo = {
+      config: axiosError.config,
+    };
+
+    if (axiosError.response) {
+      // The request was made and the server responded with a status code
+      // that falls out of the range of 2xx
+      return {
+        ...errorInfo,
+        data: axiosError.response.data,
+        status: axiosError.response.status,
+        headers: axiosError.response.headers,
+      };
+    }
+    if (axiosError.request) {
+      // The request was made but no response was received
+      // `error.request` is an instance of http.ClientRequest in node.js
+      return {
+        ...errorInfo,
+        request: axiosError.request,
+      };
+    }
+
+    // Something happened in setting up the request that triggered an Error
+    return {
+      ...errorInfo,
+      message: axiosError.message,
+    };
+  };
+
+  /**
    * Handle error response
    * @param {Error} error error object or something and inheirits from it
    * @param {number} [codeOverride] optionally override the code specified in the error
@@ -60,6 +97,10 @@ module.exports = function ResponseBuilder() {
    * @private
    */
   self._errorResponse = (error, codeOverride, req) => {
+    if (error.isAxiosError) {
+      log.error(`@backend-utils:errorResponse - error:axios:${JSON.stringify(self._getAxiosError(error))}`);
+    }
+
     if (!(error instanceof Error)) {
       if (error instanceof String) {
         return self._errorResponse(new VError(error), codeOverride);


### PR DESCRIPTION
In case of axios request error extract only necessary props and log them according to https://github.com/axios/axios#handling-errors

It will log something like this:

<img width="1414" alt="Screen Shot 2021-01-14 at 00 58 05" src="https://user-images.githubusercontent.com/11072142/104527148-59b7ae80-5604-11eb-890c-c5dd61dfebfe.png">
