### PR TITLE
fix: export entire express-validator model

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { default as ExceptionHandler } from './exceptionHandler';
 export { default as FixtureGenerator } from './fixtureGenerator';
 export { default as ResponseBuilder } from './responseBuilder';
-export { default as Validator } from 'express-validator';
+export * as Validator from 'express-validator';


### PR DESCRIPTION
### Brief description. What is this change?

* conversion to typescript broke the `Validator` export which should be the entire `express-validator` module