### PR TITLE
feat: add rate limiter module from general-runtime (VF-153)

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -21,6 +21,7 @@
     "fixpack",
     "husky",
     "lint-staged",
-    "install-peers-cli"
+    "install-peers-cli",
+    "ioredis"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/bluebird": "^3.5.33",
     "@types/chai": "^4.2.16",
     "@types/express": "^4.17.11",
+    "@types/ioredis": "^4.26.4",
     "@types/lodash": "^4.14.168",
     "@types/luxon": "^1.26.4",
     "@types/sinon": "^10.0.0",
@@ -26,6 +27,7 @@
     "http-status": "^1.4.2",
     "lodash": "^4.17.11",
     "luxon": "^1.21.3",
+    "rate-limiter-flexible": "^2.2.2",
     "sinon": "^10.0.0"
   },
   "devDependencies": {

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,0 +1,1 @@
+export * from './rateLimiter';

--- a/src/clients/rateLimiter.ts
+++ b/src/clients/rateLimiter.ts
@@ -1,0 +1,55 @@
+import type IORedis from 'ioredis';
+import { RateLimiterMemory, RateLimiterRedis, RateLimiterStoreAbstract } from 'rate-limiter-flexible';
+
+export type RateLimiter = RateLimiterStoreAbstract;
+
+// public rate limiter - req from creator-app or clients without an authorization
+const RATE_LIMITER_PUBLIC_SUFFIX = '-rate-limiter-public';
+// private rate limiter - req from clients with authorization (auth_vf token or api key)
+const RATE_LIMITER_PRIVATE_SUFFIX = '-rate-limiter-private';
+
+export interface RateLimiterOptions {
+  points: number;
+  duration: number;
+}
+
+export interface RateLimiterConfig {
+  public: RateLimiterOptions;
+  private: RateLimiterOptions;
+}
+
+export const RateLimiterClient = (
+  serviceName: string,
+  redis: IORedis.Redis | null,
+  { public: _public, private: _private }: RateLimiterConfig
+): { public: RateLimiter; private: RateLimiter } => {
+  if (redis) {
+    return {
+      public: new RateLimiterRedis({
+        points: _public.points,
+        duration: _public.duration,
+        keyPrefix: `${serviceName}${RATE_LIMITER_PUBLIC_SUFFIX}`,
+        storeClient: redis,
+      }),
+      private: new RateLimiterRedis({
+        points: _private.points,
+        duration: _private.duration,
+        keyPrefix: `${serviceName}${RATE_LIMITER_PRIVATE_SUFFIX}`,
+        storeClient: redis,
+      }),
+    };
+  }
+
+  return {
+    public: new RateLimiterMemory({
+      points: _public.points,
+      duration: _public.duration,
+      keyPrefix: `${serviceName}${RATE_LIMITER_PUBLIC_SUFFIX}`,
+    }),
+    private: new RateLimiterMemory({
+      points: _private.points,
+      duration: _private.duration,
+      keyPrefix: `${serviceName}${RATE_LIMITER_PRIVATE_SUFFIX}`,
+    }),
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './clients';
 export { default as ExceptionHandler } from './exceptionHandler';
 export { default as FixtureGenerator } from './fixtureGenerator';
 export { default as ResponseBuilder } from './responseBuilder';

--- a/tests/clients/rateLimiter.unit.ts
+++ b/tests/clients/rateLimiter.unit.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import _ from 'lodash';
+import sinon from 'sinon';
+
+import { RateLimiterClient } from '../../src/clients/rateLimiter';
+
+describe('rateLimiter client unit tests', () => {
+  beforeEach(() => {
+    sinon.restore();
+  });
+
+  it('constructor', async () => {
+    const redis = 'redis-client';
+    const config = {
+      public: {
+        points: 1000,
+        duration: 60,
+      },
+      private: {
+        points: 500,
+        duration: 60,
+      },
+    };
+
+    const limiter = RateLimiterClient('foo-service', redis as any, config as any);
+
+    expect(_.get(limiter.public, '_client')).to.eq(redis);
+    expect(_.get(limiter.public, '_points')).to.eq(config.public.points);
+    expect(_.get(limiter.public, '_duration')).to.eq(config.public.duration);
+    expect(_.get(limiter.public, '_keyPrefix')).to.eq('foo-service-rate-limiter-public');
+
+    expect(_.get(limiter.private, '_client')).to.eq(redis);
+    expect(_.get(limiter.private, '_points')).to.eq(config.private.points);
+    expect(_.get(limiter.private, '_duration')).to.eq(config.private.duration);
+    expect(_.get(limiter.private, '_keyPrefix')).to.eq('foo-service-rate-limiter-private');
+  });
+});

--- a/tests/exceptionHandler.unit.ts
+++ b/tests/exceptionHandler.unit.ts
@@ -2,6 +2,7 @@
 
 import VError from '@voiceflow/verror';
 import { expect } from 'chai';
+import { Request } from 'express';
 import sinon from 'sinon';
 
 import { ExceptionHandler, ResponseBuilder } from '../src';
@@ -13,7 +14,7 @@ describe('exceptionHandler unit tests', () => {
     const req = {
       originalUrl: 'http://google.com',
       method: 'POST',
-    };
+    } as Request;
     const res = { status: sinon.stub().returns({ json: sinon.stub() }) };
 
     await exceptionHandler.handleNotFound(req, res);
@@ -31,7 +32,7 @@ describe('exceptionHandler unit tests', () => {
     const exceptionHandler = new ExceptionHandler(new ResponseBuilder());
 
     const error = new VError('boom');
-    const req = {};
+    const req = {} as Request;
     const res = { status: sinon.stub().returns({ json: sinon.stub() }) };
     const next = sinon.stub();
 

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": [
+      "mocha"
+    ]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -595,6 +595,13 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/ioredis@^4.26.4":
+  version "4.26.4"
+  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.26.4.tgz#a2b1ed51ddd2c707d7eaac5017cc34a0fe51558a"
+  integrity sha512-QFbjNq7EnOGw6d1gZZt2h26OFXjx7z+eqEnbCHSrDI1OOLEgOHMKdtIajJbuCr9uO+X9kQQRe7Lz6uxqxl5XKg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
@@ -5286,6 +5293,11 @@ range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+rate-limiter-flexible@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-2.2.2.tgz#7b5cab0a26cde2bb08b2807437c221249fd0bad3"
+  integrity sha512-8qpJC/Zc/0dM9BW21/JyROt6eUeLZ8l06vrSWZFwgNV9IpthIJe6Pcuowpzxe0PJ3vYDaECiqvF/1J/+Nh5wgA==
 
 raw-body@2.4.0:
   version "2.4.0"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-153**

### Brief description. What is this change?

* add a rate limiter module which can be re-used across services

### Implementation details. How do you make this change?

* copied from [this implementation](https://github.com/voiceflow/general-runtime/blob/07c2bdc1ace91f49f130c63273312fc2dd95ed3f/lib/clients/rateLimiter.ts) in `general-runtime`
