### PR TITLE
feat: fix version number (VF-000)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["editorconfig.editorconfig", "dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "mikestead.dotenv"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
+  "eslint.format.enable": true,
+  "eslint.lintTask.enable": true,
+  "eslint.packageManager": "yarn",
+  "javascript.updateImportsOnFileMove.enabled": "always",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
BREAKING CHANGE: Version bump

**Fixes or implements VF-000**

### Brief description. What is this change?

Release v3.4.0 included breaking changes, this PR is effectively an empty commit that will trigger a major release. After v4.0.0 is released in this PR we run

```sh
npm deprecate @voiceflow/backend-utils@^3.4.0 'v3.4.0 accidentally introduced breaking changes, use v4.0.0 instead'
```

This will force users to go from v3.3.0 -> v4.0.0, and prevent anyone from accidentally installing the broken version.

### Implementation details. How do you make this change?

might as well add our VS Code config while we're here

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
