### PR TITLE
feat: support more envs in `getNodeEnv` (VF-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/lodash": "^4.14.168",
     "@types/luxon": "^1.26.4",
     "@types/sinon": "^10.0.0",
-    "@voiceflow/common": "7.2.0",
+    "@voiceflow/common": "7.3.0",
     "@voiceflow/logger": "1.6.0",
     "@voiceflow/verror": "^1.1.0",
     "bluebird": "^3.7.2",

--- a/src/env.ts
+++ b/src/env.ts
@@ -57,6 +57,8 @@ export const getNodeEnv = (envVar = 'NODE_ENV'): Environment => {
   const raw = getRequiredProcessEnv(envVar);
 
   switch (raw) {
+    case Environment.DEVELOPMENT:
+      return Environment.DEVELOPMENT;
     case Environment.E2E:
       return Environment.E2E;
     case Environment.LOCAL:

--- a/src/env.ts
+++ b/src/env.ts
@@ -52,8 +52,8 @@ export const setupEnv = (rootDir = process.cwd()): void => {
 };
 /* eslint-enable no-console */
 
-const environments: ReadonlySet<unknown> = new Set(Object.values(Environment));
-const environmentIsValid = (env: unknown): env is Environment => environments.has(env);
+const validEnvironments: ReadonlySet<unknown> = new Set(Object.values(Environment));
+const environmentIsValid = (env: unknown): env is Environment => validEnvironments.has(env);
 
 /** @throws if `process.env[key]` is not a valid {@link Environment}. */
 export const getNodeEnv = (envVar = 'NODE_ENV'): Environment => {
@@ -63,5 +63,5 @@ export const getNodeEnv = (envVar = 'NODE_ENV'): Environment => {
     return raw;
   }
 
-  throw new RangeError(`Invalid ${envVar} value: ${raw} - expected one of ${[...environments].join(', ')}`);
+  throw new RangeError(`Invalid ${envVar} value: ${raw} - expected one of: ${[...validEnvironments].join(', ')}`);
 };

--- a/src/env.ts
+++ b/src/env.ts
@@ -52,22 +52,16 @@ export const setupEnv = (rootDir = process.cwd()): void => {
 };
 /* eslint-enable no-console */
 
+const environments: ReadonlySet<unknown> = new Set(Object.values(Environment));
+const environmentIsValid = (env: unknown): env is Environment => environments.has(env);
+
 /** @throws if `process.env[key]` is not a valid {@link Environment}. */
 export const getNodeEnv = (envVar = 'NODE_ENV'): Environment => {
   const raw = getRequiredProcessEnv(envVar);
 
-  switch (raw) {
-    case Environment.DEVELOPMENT:
-      return Environment.DEVELOPMENT;
-    case Environment.E2E:
-      return Environment.E2E;
-    case Environment.LOCAL:
-      return Environment.LOCAL;
-    case Environment.PRODUCTION:
-      return Environment.PRODUCTION;
-    case Environment.TEST:
-      return Environment.TEST;
-    default:
-      throw new RangeError(`Invalid ${envVar} value: ${raw}`);
+  if (environmentIsValid(raw)) {
+    return raw;
   }
+
+  throw new RangeError(`Invalid ${envVar} value: ${raw} - expected one of ${[...environments].join(', ')}`);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,10 +1113,10 @@
   dependencies:
     "@commitlint/config-conventional" "^12.1.4"
 
-"@voiceflow/common@7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/common/-/common-7.2.0.tgz#b5db02fbf050efa5c673e2666872f8c0926689d3"
-  integrity sha512-/HPUqmvz4xZXJ4fXD/TpJ+y+z8bfu42iTC3os6HsSZyH5LlxwUyQ8CcTmpr9rMyMKQGgkMqoOYNb8MAJOdvowg==
+"@voiceflow/common@7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/common/-/common-7.3.0.tgz#3f05afd3bffec1947fa631543b48e6278239d00d"
+  integrity sha512-Z8FHrxOH8PuG4AXfzNdDVcJRrhCB0wdqwgQ9wCgys8dm4fO/DSwhgEsmNknRKfspsnNGwa41bWyBlPnpx1EKDA==
   dependencies:
     "@types/crypto-js" "^4.0.2"
     bson-objectid "^2.0.1"


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

this makes it easier to update the allowed environments

should have written it like this originally

upgrading `@voiceflow/common` means `development` is now an allowed env

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
