### PR TITLE
fix: move @voiceflow/common to peerDependencies (VF-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@types/lodash": "^4.14.168",
     "@types/luxon": "^1.26.4",
     "@types/sinon": "^10.0.0",
-    "@voiceflow/common": "7.3.0",
     "@voiceflow/logger": "1.6.0",
     "@voiceflow/verror": "^1.1.0",
     "bluebird": "^3.7.2",
@@ -74,6 +73,7 @@
   "license": "ISC",
   "main": "build/index.js",
   "peerDependencies": {
+    "@voiceflow/common": "^7.2.0",
     "express-validator": "^6.3.0"
   },
   "prettier": "@voiceflow/prettier-config",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/mocha": "^8.2.2",
     "@types/supertest": "^2.0.11",
     "@voiceflow/commitlint-config": "1.1.0",
+    "@voiceflow/common": "7.6.3",
     "@voiceflow/eslint-config": "5.1.0",
     "@voiceflow/git-branch-check": "1.2.0",
     "@voiceflow/prettier-config": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,10 +1113,10 @@
   dependencies:
     "@commitlint/config-conventional" "^12.1.4"
 
-"@voiceflow/common@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/common/-/common-7.3.0.tgz#3f05afd3bffec1947fa631543b48e6278239d00d"
-  integrity sha512-Z8FHrxOH8PuG4AXfzNdDVcJRrhCB0wdqwgQ9wCgys8dm4fO/DSwhgEsmNknRKfspsnNGwa41bWyBlPnpx1EKDA==
+"@voiceflow/common@7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@voiceflow/common/-/common-7.6.3.tgz#70714e0f914f0d696c02fbf8151731fc399c5e66"
+  integrity sha512-euVAkPzyXeUoXtKB+pWJtlDlZha6TCUG76zQ9U8eLuctmq1qc14L4zBvJUeKJARqfVqLjvCeEac5+mkQmIZSlg==
   dependencies:
     "@types/crypto-js" "^4.0.2"
     bson-objectid "^2.0.1"


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

move `@voiceflow/common` to peerDependencies

prevents assertion errors from being thrown because of an outdated version

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written