### PR TITLE
fix: fix ioredis dependency kinds (VF-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     }
   },
   "dependencies": {
-    "@types/ioredis": "^4.28.10",
     "@voiceflow/logger": "1.6.1",
     "@voiceflow/verror": "^1.1.0",
     "chai": "^4.3.4",
@@ -34,6 +33,7 @@
     "@types/chai-as-promised": "^7.1.4",
     "@types/express": "^4.17.13",
     "@types/http-errors": "^1.8.2",
+    "@types/ioredis": "^4.28.10",
     "@types/lodash": "^4.14.168",
     "@types/luxon": "^1.26.4",
     "@types/mocha": "9.1.0",
@@ -78,8 +78,10 @@
   "main": "build/index.js",
   "peerDependencies": {
     "@types/express": "^4.17.13",
+    "@types/ioredis": "^4.28.10",
     "@voiceflow/common": "^7.2.0",
     "express-validator": "^6.3.0",
+    "ioredis": "^4.28.5",
     "jszip": "^3.7.1"
   },
   "prettier": "@voiceflow/prettier-config",


### PR DESCRIPTION
**Fixes or implements VF-000**

### Brief description. What is this change?

change the kinds of dependencies used for ioredis and @types/ioredis

fixes errors where the version of `@types/ioredis` here are mismatched with the versions in a downstream service

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
