### PR TITLE
[Merged by Bors] - feat: upgrade typescript (VF-000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@voiceflow/git-branch-check": "1.2.3",
     "@voiceflow/prettier-config": "1.0.7",
     "@voiceflow/tsconfig": "1.2.5",
-    "@zerollup/ts-transform-paths": "^1.7.18",
     "chai-as-promised": "^7.1.1",
     "commitizen": "4.2.4",
     "cz-conventional-changelog": "^3.3.0",
@@ -64,8 +63,9 @@
     "rimraf": "^3.0.2",
     "supertest": "6.2.2",
     "ts-mocha": "9.0.2",
-    "ttypescript": "1.5.13",
-    "typescript": "4.5.5"
+    "ttypescript": "^1.5.13",
+    "typescript": "~4.7.2",
+    "typescript-transform-paths": "3.3.1"
   },
   "files": [
     "build/**"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "plugins": [
       {
-        "transform": "@zerollup/ts-transform-paths"
+        "transform": "typescript-transform-paths"
       }
     ]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@voiceflow/tsconfig",
   "compilerOptions": {
     "baseUrl": "./src",
-    "lib": ["ES2020"]
+    "target": "ES2021",
+    "lib": ["ES2021"]
   },
   "compileOnSave": false,
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7053,7 +7053,7 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
-ttypescript@1.5.13:
+ttypescript@^1.5.13:
   version "1.5.13"
   resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.13.tgz#c3bcb760599fe49157d30c5d5895a0023cbb7f30"
   integrity sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==
@@ -7117,10 +7117,22 @@ typescript-fsa@3.0.0:
   resolved "https://registry.yarnpkg.com/typescript-fsa/-/typescript-fsa-3.0.0.tgz#3ad1cb915a67338e013fc21f67c9b3e0e110c912"
   integrity sha512-xiXAib35i0QHl/+wMobzPibjAH5TJLDj+qGq5jwVLG9qR4FUswZURBw2qihBm0m06tHoyb3FzpnJs1GRhRwVag==
 
-typescript@4.5.5, typescript@^4.4.3:
+typescript-transform-paths@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/typescript-transform-paths/-/typescript-transform-paths-3.3.1.tgz#74526bc1b6dc575ffe269cc81833db7bd81763e1"
+  integrity sha512-c+8Cqd2rsRtTU68rJI0NX/OtqgBDddNs1fIxm1nCNyhn0WpoyqtpUxc1w9Ke5c5kgE4/OT5xYbKf2cf694RYEg==
+  dependencies:
+    minimatch "^3.0.4"
+
+typescript@^4.4.3:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
+typescript@~4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
+  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
 
 unbox-primitive@^1.0.0, unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

Upgrades Typescript to 4.7

Node 16 supports `ES2021`, so the target is updated.

`@zerollup/ts-transform-paths` does not support TS 4.5+, so it is replaced with `typescript-transform-paths`.