### PR TITLE
[Merged by Bors] - fix: type declaration path aliases (VF-000)

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,9 +4,8 @@
     "outDir": "./build",
     "declaration": true,
     "plugins": [
-      {
-        "transform": "typescript-transform-paths"
-      }
+      { "transform": "typescript-transform-paths" },
+      { "transform": "typescript-transform-paths", "afterDeclarations": true }
     ]
   },
   "exclude": [


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

Path aliases in type declaration files were not being resolved during build time, so types for packages that imported this as a dependency are broken.