### PR TITLE
fix: environment file not standard

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -46,8 +46,6 @@ export const setupEnv = (rootDir = process.cwd()): void => {
   } else if (fs.existsSync(path.join(rootDir, '.env'))) {
     console.log('No Environment Set/Not Found! Running default .env file');
     dotenv.config();
-  } else {
-    console.log('No Environment Set/Not Found! Hope you have your environment declared :O');
   }
 };
 /* eslint-enable no-console */


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?
None of our production instances, or VFCLI environments, use an `.env` file, and instead just directly use environment variables when starting the process.

Yes the message is fun, but I am also tired of seeing this:
![Screen Shot 2022-08-08 at 12 14 27 AM](https://user-images.githubusercontent.com/5643574/183337833-dd2ed1a2-c2c7-461e-b039-5657845e4dcb.png)


