### PR TITLE
[Merged by Bors] - fix: safer error formatting (PL-000)

### DIFF
--- a/src/middlewares/exception/index.ts
+++ b/src/middlewares/exception/index.ts
@@ -10,17 +10,23 @@ export class ExceptionMiddleware extends AbstractMiddleware<never, never> {
   }
 
   public handleError(err: unknown, req: Request, res: Response, _next: NextFunction): void {
-    log.error(`Exception formatter (pre) ${JSON.stringify(err)}`);
+    try {
+      log.error(`Exception formatter (pre) ${JSON.stringify(err)}`);
 
-    const { statusCode, ...body } = formatError(err);
+      const { statusCode, ...body } = formatError(err);
 
-    const error = {
-      ...body,
-      requestID: req.id.toString(),
-    };
+      const error = {
+        ...body,
+        requestID: req.id?.toString(),
+      };
 
-    log.error(`Exception formatter (post) ${JSON.stringify(error)}`);
+      log.error(`Exception formatter (post) ${JSON.stringify(error)}`);
 
-    res.status(statusCode).send(error);
+      res.status(statusCode).send(error);
+    } catch {
+      res.status(500).send({
+        error: err,
+      });
+    }
   }
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-XXX**

### Brief description. What is this change?

I found that sometimes `req.id` was undefined, which caused this to throw. Added an optional chaining operator.
Also added a `try/catch` as a _real_ safety net.