### PR TITLE
ci(sonar): use latest sonarcloud orb (IN-976)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   vfcommon: voiceflow/common@0.0.287
-  sonarcloud: sonarsource/sonarcloud@1.0.2
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 jobs:
   test:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
# **Fixes or implements IN-976**
### Brief description. What is this change?
Use latest sonarcloud orb vesrsion
